### PR TITLE
Remove the 'import' button on the config sync page

### DIFF
--- a/modules/custom/core/govcms_security/govcms_security.module
+++ b/modules/custom/core/govcms_security/govcms_security.module
@@ -114,6 +114,19 @@ function govcms_security_form_tfa_settings_form_alter(&$form, FormStateInterface
 }
 
 /**
+ * Implement hook_form_FORM_ID_alter()
+ *
+ * Disable the Import all button for all users from User Interface.
+ * Display a message around disabled config synchronization.
+ *
+ */
+function govcms_security_form_config_admin_import_form_alter(&$form, FormStateInterface $form_state) {
+  $form['actions']['submit']['#access'] = FALSE;
+  \Drupal::messenger()->addMessage("Configuration import is blocked via govcms_security module.");
+}
+
+
+/**
  * Implements hook_form_alter().
  */
 function govcms_security_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
* https://osbfinance.atlassian.net/browse/GOVCMSD10-432
* Remove the 'import' button on the config sync page
* Implemented a hook_form_alter

**Example of the button which needs to be removed**
![SaaS site before form alter- import button available](https://github.com/govCMS/GovCMS/assets/131833916/814f372b-72b2-48e7-af86-cbad970d1aed)

**SaaS site tested: Button removed for all users**
![Saas site - removed import button for all users](https://github.com/govCMS/GovCMS/assets/131833916/9e9df76c-7124-4225-9ea4-9798d584acf7)

**PaaS site tested: Button removed for all users**
![PaaS site - removed import button for all users](https://github.com/govCMS/GovCMS/assets/131833916/9084e124-6847-4b4d-a3fb-67f6db5caa5f)